### PR TITLE
polished README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-### svg-explorer-extension
-This repo imported from https://svgextension.codeplex.com/
+# SVG Viewer Extension for Windows Explorer
+Extension module for Windows Explorer to render SVG thumbnails, so that you can have an overview of your SVG files.
 
-Installation: From _[Releases](https://github.com/maphew/svg-explorer-extension/releases)_ download and run appropriate binary for your system, then kill `explorer.exe` and icon cache
+## Installation
+From _[Releases](https://github.com/maphew/svg-explorer-extension/releases)_ download and run appropriate binary for your system, then kill `explorer.exe` and icon cache
 ([ref](https://superuser.com/questions/342052/how-to-get-svg-thumbnails-in-windows-explorer)):
    
     TASKKILL /IM explorer* /F
     DEL "%localappdata%\IconCache.db" /A
     explorer.exe
+   
+You can just simply use the provided binary installers. Make sure you download the right architecture (the 32 bit installer will run on a 64 bit system, but the extension will not function).
+
+## svg-explorer-extension - developer note
+This repo was imported from https://svgextension.codeplex.com/
 
 I imported the svg-explorer-extension from CodePlex posted here to GitHub because I use the extension and I didn't want to lose access to it when CodePlex shut down in 2017. 
 
@@ -24,37 +30,12 @@ Warning: it's many GB.
   - `choco install visualstudio2017-workload-vctools`
 - Windows SDK - `choco install windows-sdk-10.-0`
 
-Installation is with [Chocolatey ](https://chocolatey.org/) wherever I have a choice. The list may be incomplete. I've installed and uninstalled several different programs and versions of programs trying to find the right combination.
+Installation is with [Chocolatey](https://chocolatey.org/) wherever I have a choice. The list may be incomplete. I've installed and uninstalled several different programs and versions of programs trying to find the right combination.
 
 More info: https://github.com/maphew/svg-explorer-extension/issues/18
 
 
------
-*Original readme follows:*
+## Thanks to
 
------
-# SVG Viewer Extension for Windows Explorer
-Extension module for Windows Explorer to render SVG thumbnails, so that you can have an overview of your SVG files.
-
-## NOTE
-New signed installer have been uploaded from version 0.1.1 thanks to www.certum.eu! In this version only the installer is signed, but from now on both the DLLs and the installers will be signed.
-Installation
-You can just simply use the provided binary installers. Make sure you download the right architecture.
-
-IMPORTANT: The 32 bit installer will run on a 64 bit system, but the extension will not function.
-
-## Build
-The easiest way to build it is with the provided Qt project file. I suggest to use Qt Creator. Requirements:
-
- * Qt SDK
- * Windows 7 SDK
- * Qt SDK 64 bit (for 64 bit builds only) NOTE: You have to compile Qt for 64 bit by yourself.
-
-Thanks to
-
- * Qt @ http://qt.nokia.com/
- * Jeremy @ urk:http://www.codemonkeycodes.com/2010/01/11/ithumbnailprovider-re-visited/
-
-Last edited Feb 21, 2014 at 12:29 AM by Tibold, version 4
-
------
+ * [Qt](https://www.qt.io/)
+ * [Jeremy@urk](https://www.codemonkeycodes.com/2010/01/11/ithumbnailprovider-re-visited/)


### PR DESCRIPTION
* integrated "old" README instead of having both split
* updated URLs

Note: the "old" README perfectly shown in the codeplex archive that can be reached with the integrated link