### PR TITLE
fixed missing files in installer

### DIFF
--- a/SVGThumbnailExtension/Main.cpp
+++ b/SVGThumbnailExtension/Main.cpp
@@ -1,5 +1,7 @@
 #define INITGUID
 #include "Common.h"
+#include <QtCore/QFileInfo>
+#include <QtCore/private/qcoreapplication_p.h>
 
 
 HINSTANCE g_hinstDll = NULL;
@@ -36,6 +38,17 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDll,
    {
    case DLL_PROCESS_ATTACH:
       g_hinstDll = hinstDll;
+
+      // qt.conf file won't be found, because the applicationFilePath is set to
+      // the calling process name, which is "C:\Windows\System32\regsvr32.exe"
+      // and not the absolute path to the dll, fix it by setting the
+      // applicationFilePath manually with the private method
+      // (I don't like this approach but it works for now)
+      TCHAR buffer[MAX_PATH];
+      GetModuleFileName(hinstDll, buffer, MAX_PATH);
+      QCoreApplicationPrivate::setApplicationFilePath(
+          QFileInfo(QString::fromWCharArray(buffer)).filePath());
+
       int c = 0;
       app = new QApplication(c, (char **)0, 0);
       break;

--- a/SVGThumbnailExtension/SVGThumbnailExtension.iss
+++ b/SVGThumbnailExtension/SVGThumbnailExtension.iss
@@ -24,11 +24,14 @@ Name: "en"; MessagesFile: "compiler:Default.isl"; LicenseFile: "license.txt"
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+Source: "qt.conf"; DestDir: "{app}";
 Source: "x86\release\Qt5Core.dll"; DestDir: "{app}";
 Source: "x86\release\Qt5Gui.dll"; DestDir: "{app}";
 Source: "x86\release\Qt5Svg.dll"; DestDir: "{app}";
 Source: "x86\release\Qt5Widgets.dll"; DestDir: "{app}";
 Source: "x86\release\Qt5WinExtras.dll"; DestDir: "{app}";
+Source: "x86\release\plugins\platforms\qwindows.dll"; DestDir: "{app}\plugins\platforms\";
+Source: "x86\release\plugins\styles\qwindowsvistastyle.dll"; DestDir: "{app}\plugins\styles\";
 Source: "..\SVGThumbnailExtension-build-x86_Release\release\SVGThumbnailExtension.dll"; DestDir: "{app}"; Flags: regserver         
 ; Licenses
 ; FIXME: the qt license should not be stored in this repository but be copied from the qt distribution

--- a/SVGThumbnailExtension/SVGThumbnailExtension.pro
+++ b/SVGThumbnailExtension/SVGThumbnailExtension.pro
@@ -6,6 +6,7 @@
 
 QT       += svg
 QT       += winextras
+QT       += core-private
 
 TARGET = SVGThumbnailExtension
 TEMPLATE = lib

--- a/SVGThumbnailExtension/SVGThumbnailExtension_x64.iss
+++ b/SVGThumbnailExtension/SVGThumbnailExtension_x64.iss
@@ -25,11 +25,14 @@ Name: "en"; MessagesFile: "compiler:Default.isl"; LicenseFile: "license.txt"
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+Source: "qt.conf"; DestDir: "{app}";
 Source: "x64\release\Qt5Core.dll"; DestDir: "{app}";
 Source: "x64\release\Qt5Gui.dll"; DestDir: "{app}";
 Source: "x64\release\Qt5Svg.dll"; DestDir: "{app}";
 Source: "x64\release\Qt5Widgets.dll"; DestDir: "{app}";
 Source: "x64\release\Qt5WinExtras.dll"; DestDir: "{app}";
+Source: "x64\release\plugins\platforms\qwindows.dll"; DestDir: "{app}\plugins\platforms\";
+Source: "x64\release\plugins\styles\qwindowsvistastyle.dll"; DestDir: "{app}\plugins\styles\";
 Source: "..\SVGThumbnailExtension-build-x64_Release\release\SVGThumbnailExtension.dll"; DestDir: "{app}"; Flags: regserver
 ; Licenses
 ; FIXME: the qt license should not be stored in this repository but be copied from the qt distribution

--- a/SVGThumbnailExtension/qt.conf
+++ b/SVGThumbnailExtension/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Prefix=.


### PR DESCRIPTION
referring to #27 

I played around with AppVeyor and noticed that the build artifacts won't work.
I hopefully found a fix for that so that the library can be registered during the install process.

Here is my AppVeyor build script:
```
set VC_DIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
set INNOSETUP_DIR=C:\Program Files (x86)\Inno Setup 5
set JOM=C:\Qt\Tools\QtCreator\bin\jom.exe
set QMAKESPEC=win32-msvc
set PATH=%INNOSETUP_DIR%;%VC_DIR%;%PATH%
set PATH_BAK=%PATH%

cd SVGThumbnailExtension
mkdir license
copy C:\Qt\Licenses\LICENSE license\Qt.txt
copy ..\LICENSE.md license.txt
cd ..

echo ####################################################
echo Building 64bit installer
echo ####################################################

set QT_DIR=C:\Qt\5.13.2\msvc2017_64
set PATH=%QT_DIR%\bin;%PATH_BAK%
set BUILD_DIR=SVGThumbnailExtension-build-x64_Release

call vcvars64.bat || exit /B 1

mkdir %BUILD_DIR%
cd %BUILD_DIR%
qmake.exe ..\SVGThumbnailExtension\SVGThumbnailExtension.pro "CONFIG+=release"
%JOM%

cd ..\SVGThumbnailExtension
set ARCH=x64
mkdir %ARCH%\release\plugins\platforms
mkdir %ARCH%\release\plugins\styles
FOR %%G IN (Qt5Core,Qt5Gui,Qt5Svg,Qt5Widgets,Qt5WinExtras) DO copy %QT_DIR%\bin\%%G.dll %ARCH%\release
copy %QT_DIR%\plugins\platforms\qwindows.dll %ARCH%\release\plugins\platforms
copy %QT_DIR%\plugins\styles\qwindowsvistastyle.dll %ARCH%\release\plugins\styles
ISCC SVGThumbnailExtension_x64.iss
cd ..

echo ####################################################
echo Building 32bit installer
echo ####################################################

set QT_DIR=C:\Qt\5.13.2\msvc2017
set PATH=%QT_DIR%\bin;%PATH_BAK%
set BUILD_DIR=SVGThumbnailExtension-build-x86_Release

call vcvars32.bat || exit /B 1

mkdir %BUILD_DIR%
cd %BUILD_DIR%
qmake.exe ..\SVGThumbnailExtension\SVGThumbnailExtension.pro "CONFIG+=release"
%JOM%

cd ..\SVGThumbnailExtension
set ARCH=x86
mkdir %ARCH%\release\plugins\platforms
mkdir %ARCH%\release\plugins\styles
FOR %%G IN (Qt5Core,Qt5Gui,Qt5Svg,Qt5Widgets,Qt5WinExtras) DO copy %QT_DIR%\bin\%%G.dll %ARCH%\release
copy %QT_DIR%\plugins\platforms\qwindows.dll %ARCH%\release\plugins\platforms
copy %QT_DIR%\plugins\styles\qwindowsvistastyle.dll %ARCH%\release\plugins\styles
ISCC SVGThumbnailExtension.iss
cd ..
```

Deploying build artifacts to GitHub also works, see [GitHub deployment](https://www.appveyor.com/docs/deployment/github/)
You need to create a new "Environment" and choose "GitHub Releases" as provider.
I used the following settings:
```
Name: development-builds
Release description: svg-explorer-extension-v$(appveyor_build_version)
GitHub authentication token: <github token from https://github.com/settings/tokens>
Artifact(s) to deploy: /installer\/.*\.exe/
Draft release: checked
```

This pull request may not run successfully until you changed the AppVeyor build script.
