### PR TITLE
fix broken QT4 support

### DIFF
--- a/SVGThumbnailExtension/Common.h
+++ b/SVGThumbnailExtension/Common.h
@@ -28,7 +28,11 @@ STDAPI_(HINSTANCE) DllInstance();
 DEFINE_GUID(CLSID_SampleThumbnailProvider,
 0x4ca20d9a, 0x98ac, 0x4dd6, 0x9c, 0x16, 0x74, 0x49, 0xf2, 0x9a, 0xc0, 0x8a);
 
+#if QT_VERSION < 0x050200
+#include <Qt/QApplication.h>
+#else
 #include <QtWidgets/QApplication>
+#endif
 #include <QtSvg/QSvgRenderer>
 
 #endif // SVGTHUMBNAILEXTENSION_GLOBAL_H

--- a/SVGThumbnailExtension/ThumbnailProvider.cpp
+++ b/SVGThumbnailExtension/ThumbnailProvider.cpp
@@ -4,10 +4,12 @@
 #include <QtGui/QImage>
 #include <QtGui/QPixmap>
 #include <QtGui/QPainter>
+#if QT_VERSION >= 0x050200
 #include <QtWin>
+#endif
 #include <QtCore/QFile>
-#include <QString>
-#include <QDateTime>
+#include <QtCore/QString>
+#include <QtCore/QDateTime>
 #include "assert.h"
 
 using namespace Gdiplus;
@@ -141,14 +143,15 @@ STDMETHODIMP CThumbnailProvider::GetThumbnail(UINT cx,
 #ifndef NDEBUG
     device->save(QString("C:\\dev\\%1.png").arg(QDateTime::currentMSecsSinceEpoch()), "PNG");
 #endif
-    // Issue #19, https://github.com/maphew/svg-explorer-extension/issues/19
-    // Old syntax: HBITMAP QPixmap::toWinHBITMAP(HBitmapFormat format = NoAlpha) const
-    // New syntax: HBITMAP QtWin::toHBITMAP(const QPixmap &p, QtWin::HBitmapFormat format = HBitmapNoAlpha)
-    //
-    // Old code:
-    //*phbmp = QPixmap::fromImage(*device).toWinHBITMAP(QPixmap::Alpha);
-    // new test code:
+
+// Issue #19, https://github.com/maphew/svg-explorer-extension/issues/19
+// Old syntax: HBITMAP QPixmap::toWinHBITMAP(HBitmapFormat format = NoAlpha) const
+// New syntax: HBITMAP QtWin::toHBITMAP(const QPixmap &p, QtWin::HBitmapFormat format = HBitmapNoAlpha)
+#if QT_VERSION < 0x050200
+    *phbmp = QPixmap::fromImage(*device).toWinHBITMAP(QPixmap::Alpha);
+#else
     *phbmp = QtWin::toHBITMAP(QPixmap::fromImage(*device), QtWin::HBitmapAlpha);
+#endif
     assert(*phbmp != NULL);
 
     delete painter;

--- a/SVGThumbnailExtension/ThumbnailProvider.h
+++ b/SVGThumbnailExtension/ThumbnailProvider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QSvgRenderer>
+#include <QtSvg/QSvgRenderer>
 
 class CThumbnailProvider : public IThumbnailProvider, IObjectWithSite, IInitializeWithStream
 {


### PR DESCRIPTION
* Common.h [QT_VERSION < 0x050200]: include QApplication from Qt instead of newer QtWidgets
* ThumbnailProvider.cpp [QT_VERSION < 0x050200]: do not include QtWin and use old QPixmap code, fixing #19
* general: adjusted includes to build from qt main (using subfolders) which was partial done before, now only needing one include directory to be specified, fixing #39

tested with QT 4.7.4 and QT 4.8.1, test for QT 5.13.2 will come with the PR by the beauty of CI/CD :-)

Note: compiled on command line with the following commands (just for reference):

```cmd
cd c:\dev\svg-explorer-extension\SVGThumbnailExtension
mkdir release
rem set QT_DIR=c:\dev\QtSDK\Desktop\Qt\4.7.4\msvc2008
set QT_DIR=c:\dev\QtSDK\Desktop\Qt\4.8.1\msvc2010

cl /nologo Main.cpp ClassFactory.cpp ThumbnailProvider.cpp ThumbnailProvider.def /DNDEBUG /DUNICODE /DSVGTHUMBNAILEXTENSION_LIBRARY /DQT_NO_DEBUG /DQT_SVG_LIB /DQT_WIDGETS_LIB /DQT_WINEXTRAS_LIB /DQT_GUI_LIB /DQT_CORE_LIB /D_WINDLL /I "%QT_DIR%\include" /link /LIBPATH:"%QT_DIR%\lib"  /DLL /SUBSYSTEM:WINDOWS /DEF:ThumbnailProvider.def /MANIFEST:embed /OUT:release\SVGThumbnailExtension.dll shlwapi.lib advapi32.lib QtCore4.lib QtSvg4.lib QtGui4.lib
```