### PR TITLE
removed dependency to gdiplus

### DIFF
--- a/SVGThumbnailExtension/SVGThumbnailExtension.pro
+++ b/SVGThumbnailExtension/SVGThumbnailExtension.pro
@@ -14,8 +14,7 @@ CONFIG(release, debug|release):DEFINES += NDEBUG
 
 win32:LIBS += \
     shlwapi.lib \
-    advapi32.lib \
-    gdiplus.lib
+    advapi32.lib
 
 DEFINES += SVGTHUMBNAILEXTENSION_LIBRARY
 


### PR DESCRIPTION
When tinkering with QT4 (actually with coverity scan ;-) I did only want to use cl.exe instead of qtmake. Doing so I've just took the sources, and checked for necessary options to find out that SVGThumbnailExtension.pro has three libraries listed and and only 2 where necessary (despite of the qt libraries).
If it is not known to be necessary for some environments (and the PR passes the build test) it should be removed.