### PR TITLE
cleanup and qt4 compatibility

### DIFF
--- a/SVGThumbnailExtension/Main.cpp
+++ b/SVGThumbnailExtension/Main.cpp
@@ -1,9 +1,10 @@
 #define INITGUID
 #include "Registry.h"
 
-#include <QDebug>
-#include <QDir>
-#include <QFileInfo>
+#include <QtCore/QString>
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 
 HINSTANCE g_hinstDll = NULL;
 LONG g_cRef = 0;

--- a/SVGThumbnailExtension/ThumbnailProvider.cpp
+++ b/SVGThumbnailExtension/ThumbnailProvider.cpp
@@ -5,9 +5,11 @@
 #include <assert.h>
 
 #include <QtCore/QDateTime>
+#ifndef NDEBUG
+#include <QtCore/QString>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
-#include <QtCore/QString>
+#endif
 #include <QtGui/QImage>
 #include <QtGui/QPainter>
 #include <QtGui/QPixmap>
@@ -190,7 +192,7 @@ STDMETHODIMP CThumbnailProvider::GetThumbnail(UINT cx,
     // Old syntax: HBITMAP QPixmap::toWinHBITMAP(HBitmapFormat format = NoAlpha) const
     // New syntax: HBITMAP QtWin::toHBITMAP(const QPixmap &p, QtWin::HBitmapFormat format = HBitmapNoAlpha)
 #if QT_VERSION < 0x050200
-    *phbmp = QPixmap::fromImage(device).toWinHBITMAP(QPixmap::Alpha);
+    *phbmp = QPixmap::fromImage(*device).toWinHBITMAP(QPixmap::Alpha);
 #else
     *phbmp = QtWin::toHBITMAP(QPixmap::fromImage(*device), QtWin::HBitmapAlpha);
 #endif


### PR DESCRIPTION
* Main.cpp: include qt headers from their include root (including the module directory)
* ThumbnailProvider.cpp [!NDEBUG]: limit includes to the scope they are used for
* ThumbnailProvider.cpp (CThumbnailProvider::GetThumbnail) [QT_VERSION < 0x050200]: retrofixed (`device` somehow lost its dereferencing)